### PR TITLE
Verbosify autopatch-* targets

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -839,7 +839,7 @@ endif
 .PHONY: autopatch-$(call dep_name,$1)
 
 autopatch-$(call dep_name,$1)::
-	if [ "$1" = "elixir" -a "$(ELIXIR_PATCH)" ]; then \
+	$(verbose) if [ "$1" = "elixir" -a "$(ELIXIR_PATCH)" ]; then \
 		ln -s lib/elixir/ebin $(DEPS_DIR)/elixir/; \
 	else \
 		$$(call dep_autopatch,$(call dep_name,$1)) \


### PR DESCRIPTION
Wrap the shell commands of autopatch-* targets in `$(verbose)` to eliminate noisy terminal output.